### PR TITLE
add stored events support

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -7,15 +7,25 @@ program
   .command('log')
   .option('-e, --event <event name>', 'Mixpanel event name')
   .option('-m, --metadata <metadata>', 'Mixpanel metadata object')
+  .option('-sea, --stored-event-action <actionType>', 'Optional for stored events.  create or append')
   .action(async (cmdObj) => {
     const {
       event,
       metadata,
+      storedEventAction,
     } = cmdObj;
 
     await MixpanelWrapper.upsertIdentity();
 
-    MixpanelWrapper.logEvent(event, JSON.parse(metadata));
+    const options = {};
+
+    if (storedEventAction) {
+      options.storedEvent = {
+        action: storedEventAction,
+      };
+    }
+
+    MixpanelWrapper.logEvent(event, JSON.parse(metadata), options);
   });
 
 module.exports = program;

--- a/index.js
+++ b/index.js
@@ -13,6 +13,18 @@ class MixpanelWrapper {
     return `${TMP_DIR}mixpanel-identifier.json`;
   }
 
+  static getStoredEventsPath() {
+    return `${TMP_DIR}stored-events.json`;
+  }
+
+  static getStoredEventsData() {
+    if (!fs.existsSync(MixpanelWrapper.getStoredEventsPath())) {
+      fs.writeFileSync(MixpanelWrapper.getStoredEventsPath(), JSON.stringify({}));
+    }
+
+    return JSON.parse(fs.readFileSync(MixpanelWrapper.getStoredEventsPath()));
+  }
+
   static async upsertIdentity() {
     const identifierPath = MixpanelWrapper.getIdentifierCompletePath();
 
@@ -37,14 +49,36 @@ class MixpanelWrapper {
         res();
       }
     });
-  })
+  });
 
-  static logEvent = (event, metadata = {}) => {
-    MixpanelWrapper._mixpanelInstance.track(event, {
+  static logEvent = (event, metadata = {}, options = {}) => {
+    const eventProperties = {
       ...metadata,
       distinct_id: MixpanelWrapper.uuid,
-    });
-  }
+    };
+
+    /**
+     * Stored events are used to identify a series of related events through a UUID.  Call with the
+     * create action for the first event and then call with append action to relate following events
+     * to the first action.
+     */
+    if (options.storedEvent && typeof options.storedEvent === 'object') {
+      const storedData = MixpanelWrapper.getStoredEventsData();
+
+      if (options.storedEvent.action === 'create') {
+        const eventUuid = uuidv4();
+        storedData[event] = eventUuid;
+        fs.writeFileSync(MixpanelWrapper.getStoredEventsPath(), JSON.stringify(storedData));
+        eventProperties.stored_event_uuid = eventUuid;
+      } else if (options.storedEvent.action === 'append') {
+        eventProperties.stored_event_uuid = storedData[event];
+      } else {
+        throw new Error('Invalid stored event option.');
+      }
+    }
+
+    MixpanelWrapper._mixpanelInstance.track(event, eventProperties);
+  };
 }
 
 module.exports = MixpanelWrapper;

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -3,6 +3,8 @@ const cli = require('../cli');
 const MixpanelWrapper = require('../index');
 
 jest.mock('../index');
+// eslint-disable-next-line global-require
+jest.mock('mixpanel', () => require('../mocks/mixpanel-mock'));
 
 describe('cli', () => {
   beforeEach(() => {
@@ -19,6 +21,30 @@ describe('cli', () => {
 
       await waitForExpect(() => {
         expect(MixpanelWrapper.logEvent).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('log with stored action', () => {
+    it('calls MixpanelWrapper with storedEvent option', async () => {
+      cli.parse(['log', '-e', 'testEvent', '-m', '{"test": "asdf"}', '-sea', 'create'], {
+        from: 'user',
+      });
+
+      expect(MixpanelWrapper.upsertIdentity).toHaveBeenCalled();
+
+      await waitForExpect(() => {
+        expect(MixpanelWrapper.logEvent).toHaveBeenCalledWith(
+          'testEvent',
+          {
+            test: 'asdf',
+          },
+          {
+            storedEvent: {
+              action: 'create',
+            },
+          }
+        );
       });
     });
   });


### PR DESCRIPTION
Tommy recommended the ability to store a UUID to track a series of related events.  This PR builds that functionality out.